### PR TITLE
fix: ScreenObserver extends NavigatorObserver

### DIFF
--- a/packages/core/lib/client.dart
+++ b/packages/core/lib/client.dart
@@ -49,7 +49,7 @@ List<FlushPolicy> defaultFlushPolicies = [
   CountFlushPolicy(30),
 ];
 
-class ScreenObserver with NavigatorObserver {
+class ScreenObserver extends NavigatorObserver {
   final StreamController<String> screenStreamController =
       StreamController.broadcast();
 


### PR DESCRIPTION
Per the Dart documentation:


> Pre-Dart 3, any class could be used as a mixin, as long as it had no declared constructors and no superclass other than Object.
> 
> In Dart 3, classes declared in libraries at language version 3.0 or later can’t be used as mixins unless marked mixin. This restriction applies to code in any library attempting to use the class as a mixin, regardless of the latter library’s language version.

https://dart.dev/resources/dart-3-migration#mixin