### PR TITLE
fix: support http v0 and v1

### DIFF
--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   json_annotation: ^4.8.0
   flutter_fgbg: ^0.2.2
   state_notifier: ^0.7.2
-  http: ^1.0.0
+  http: ">=0.13.6 <2.0.0"
   logger: ^1.1.0
   path_provider: ^2.0.12
 


### PR DESCRIPTION
This should fix https://github.com/segmentio/analytics_flutter/issues/7
While being valid for Flutter v3.10 as in https://github.com/segmentio/analytics_flutter/pull/5 