### PR TITLE
make firebaseOptions optional for FirebaseDestination plugin

### DIFF
--- a/packages/plugins/plugin_firebase/lib/plugin_firebase.dart
+++ b/packages/plugins/plugin_firebase/lib/plugin_firebase.dart
@@ -17,10 +17,12 @@ import 'package:analytics_plugin_firebase/properties.dart';
 class FirebaseDestination extends DestinationPlugin {
   final Future<void> firebaseFuture;
 
-  FirebaseDestination(FirebaseOptions? firebaseOptions)
-      : firebaseFuture = Firebase.initializeApp(
-          options: firebaseOptions,
-        ),
+  FirebaseDestination([FirebaseOptions? firebaseOptions])
+      : firebaseFuture = firebaseOptions != null
+            ? Firebase.initializeApp(
+                options: firebaseOptions,
+              )
+            : Future.value(),
         super('Firebase');
 
   @override


### PR DESCRIPTION
This pr makes the `firebaseOptions` an optional param for `FirebaseDestination` and uses default `FirebaseApp` instance if no `firebaseOptions` is provided.

Fixes #16 