### PR TITLE
Fix delete enum on widget_observer and import from lifecycle

### DIFF
--- a/packages/core/lib/utils/lifecycle/widget_observer.dart
+++ b/packages/core/lib/utils/lifecycle/widget_observer.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
+import 'package:analytics/utils/lifecycle/lifecycle.dart';
 import 'package:flutter/widgets.dart';
-
-enum AppStatus { foreground, background }
 
 abstract class LifeCycle extends Stream<AppStatus> {}
 


### PR DESCRIPTION
Fix #24 