### PR TITLE
Fix Conditional Platform Imports

### DIFF
--- a/packages/core/lib/analytics_none.dart
+++ b/packages/core/lib/analytics_none.dart
@@ -1,0 +1,7 @@
+import 'package:analytics/analytics_platform_interface.dart';
+
+/// A stub implementation of the AnalyticsPlatform of the Analytics plugin.
+class AnalyticsPlatformImpl extends AnalyticsPlatform {
+  /// Constructs a stub AnalyticsPlatform
+  AnalyticsPlatformImpl();
+}

--- a/packages/core/lib/analytics_platform_interface.dart
+++ b/packages/core/lib/analytics_platform_interface.dart
@@ -1,5 +1,7 @@
-import 'package:analytics/analytics_web.dart'
-    if (dart.library.io) 'package:analytics/analytics_pigeon.dart';
+import 'package:analytics/analytics_none.dart'
+    if (dart.library.io) 'package:analytics/analytics_pigeon.dart'
+    if (dart.library.html) 'package:analytics/analytics_web.dart';
+
 import 'package:analytics/native_context.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
@@ -30,6 +32,6 @@ abstract class AnalyticsPlatform extends PlatformInterface {
   /// A broadcast stream for receiving incoming link change events.
   ///
   /// The [Stream] emits opened links as [String]s.
-  Stream<Map<String, dynamic>> get linkStream => throw UnimplementedError(
-      'getLinksStream has not been implemented on the current platform.');
+  Stream<Map<String, dynamic>> get linkStream =>
+      throw UnimplementedError('getLinksStream has not been implemented on the current platform.');
 }

--- a/packages/core/lib/analytics_web.dart
+++ b/packages/core/lib/analytics_web.dart
@@ -6,8 +6,6 @@ import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
 import 'package:analytics/analytics_platform_interface.dart';
 
-export 'package:analytics/client.dart';
-
 /// A web implementation of the AnalyticsPlatform of the Analytics plugin.
 class AnalyticsPlatformImpl extends AnalyticsPlatform {
   /// Constructs a AnalyticsWeb


### PR DESCRIPTION
Fixed an issue with conditional imports. 
Now plugin correctly imports platform-specific dependencies and successfully builds for all supported platforms. 