### PR TITLE
Prefer ajs_anonymous_id to userInfo

### DIFF
--- a/packages/core/lib/utils/store/web.dart
+++ b/packages/core/lib/utils/store/web.dart
@@ -43,7 +43,7 @@ class StoreImpl implements Store {
           (i) => i.key == "ajs_anonymous_id",
         );
 
-        anonymousId = entry.value;
+        anonymousId = json.decode(entry.value);
       }
     } on StateError {
       anonymousId = null;

--- a/packages/core/lib/utils/store/web.dart
+++ b/packages/core/lib/utils/store/web.dart
@@ -35,6 +35,20 @@ class StoreImpl implements Store {
 
   Future<Map<String, dynamic>?> _readFromStorage(String fileKey) async {
     final fileName = _getFileName(fileKey);
+
+    String? anonymousId;
+    try {
+      if (fileKey == "userInfo") {
+        final entry = localStorage.entries.firstWhere(
+          (i) => i.key == "ajs_anonymous_id",
+        );
+
+        anonymousId = entry.value;
+      }
+    } on StateError {
+      anonymousId = null;
+    }
+
     MapEntry<String, String>? data;
     try {
       data = localStorage.entries.firstWhere((i) => i.key == fileName);
@@ -43,10 +57,28 @@ class StoreImpl implements Store {
     }
     if (data != null) {
       if (data.value == "{}") {
+        if (anonymousId != null) {
+          return {
+            "anonymousId": anonymousId,
+          };
+        }
+
         return null; // Prefer null to empty map, because we'll want to initialise a valid empty value.
       }
-      return json.decode(data.value) as Map<String, dynamic>;
+
+      final jsonMap = json.decode(data.value) as Map<String, dynamic>;
+      if (anonymousId != null) {
+        jsonMap["anonymousId"] = anonymousId;
+      }
+
+      return jsonMap;
     } else {
+      if (anonymousId != null) {
+        return {
+          "anonymousId": anonymousId,
+        };
+      }
+
       return null;
     }
   }


### PR DESCRIPTION
Addresses the issue I'm having https://github.com/segmentio/analytics_flutter/issues/46.

If the file we're trying to grab from LocalStorage is userInfo, also try to grab the ajs_anonymous_id from LocalStorage. If it's not null, replace UserInfo.anonymousId with the value from the ajs_anonymous_id. This allows us to keep our anonymousId tracking consistent across Analytics.js and analytics_flutter.

Your _readFromStorage is generic and I'm introducing changes specific to an individual file, so this probably isn't ideal, but it at least gives you a visualization what I'm trying to do.