### PR TITLE
bugfix: remove recursive identify call in Adjust plugin

### DIFF
--- a/packages/plugins/plugin_adjust/lib/plugin_adjust.dart
+++ b/packages/plugins/plugin_adjust/lib/plugin_adjust.dart
@@ -79,7 +79,6 @@ class AdjustDestination extends DestinationPlugin {
     if (anonId != null && anonId.isNotEmpty) {
       Adjust.addSessionPartnerParameter('anonymous_id', anonId);
     }
-    await identify(event);
     return event;
   }
 


### PR DESCRIPTION
Adjust.identify is called recursively, resulting in a StackOverflow error