### PR TITLE
fix:Reply already submitted

### DIFF
--- a/packages/plugins/plugin_advertising_id/android/src/main/kotlin/com/segment/plugin_advertising_id/PluginAdvertisingIdPlugin.kt
+++ b/packages/plugins/plugin_advertising_id/android/src/main/kotlin/com/segment/plugin_advertising_id/PluginAdvertisingIdPlugin.kt
@@ -41,6 +41,7 @@ class PluginAdvertisingIdPlugin: FlutterPlugin, MethodCallHandler {
 
         if (isLimitAdTrackingEnabled) {
           result.success(null)
+          return
         }
 
         val id = advertisingInfo.id


### PR DESCRIPTION
When `isLimitAdTrackingEnabled` is `true`, after `result.success(null)`, adding a `return` statement so that `return.success` is not called twice. 
Fixes #76 