### PR TITLE
docs: fixed local links in README.md

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -525,7 +525,7 @@ LogFactory.logger = CustomLogger();
 
 You can handle analytics client errors through the `errorHandler` option.
 
-The error handler configuration receives a function which will get called whenever an error happens on the analytics client. It will receive an Exception, that will extend one of the errors from [errors.dart](packages/core/lib/errors.dart).
+The error handler configuration receives a function which will get called whenever an error happens on the analytics client. It will receive an Exception, that will extend one of the errors from [errors.dart](./lib/errors.dart).
 
 You can use this error handling to trigger different behaviours in the client when a problem occurs. For example if the client gets rate limited you could use the error handler to swap flush policies to be less aggressive:
 
@@ -555,7 +555,7 @@ final analytics = createClient(Configuration(writeKey),
 
 ### Reporting errors from plugins
 
-Plugins can also report errors to the handler by using the [`.error`](packages/core/lib/analytics.dart#L52) function of the analytics client, we recommend using the `PluginError` for consistency, and attaching the `innerError` with the actual exception that was hit:
+Plugins can also report errors to the handler by using the [`.error`](./lib/analytics.dart#L55) function of the analytics client, we recommend using the `PluginError` for consistency, and attaching the `innerError` with the actual exception that was hit:
 
 ```dart
 import 'package:segment_analytics/errors.dart';
@@ -573,15 +573,15 @@ try {
 
 ## Example App
 
-See the [example app](./example/README.md) to check a full test app of how to integrate Analytics-Flutter into your own Flutter app.
+See the [example app](../../example/README.md) to check a full test app of how to integrate Analytics-Flutter into your own Flutter app.
 
 ## Contributing
 
-See the [contributing guide](CONTRIBUTING.md) to learn how to contribute to the repository and the development workflow.
+See the [contributing guide](./CONTRIBUTING.md) to learn how to contribute to the repository and the development workflow.
 
 ## Code of Conduct
 
-Before contributing, please also see our [code of conduct](CODE_OF_CONDUCT.md).
+Before contributing, please also see our [code of conduct](../../CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
Some of the links in the README are broken - linked them to where I think they are meant to go.