### PR TITLE
Update web to 1.0.0

### DIFF
--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   path_provider: ^2.0.12
   flutter_fgbg: ^0.6.0
   shared_preferences: ^2.2.2
-  web: ^0.5.1
+  web: ^1.0.0
 
 dev_dependencies:
   build_runner: ^2.3.3


### PR DESCRIPTION
Resolves an issue with share_plus and segment_analytics having conflicting web versions by updating web to a version that share_plus requires. 