### PR TITLE
Updated segment_analytics_plugin_appsflyer

### DIFF
--- a/packages/plugins/plugin_appsflyer/pubspec.yaml
+++ b/packages/plugins/plugin_appsflyer/pubspec.yaml
@@ -6,22 +6,21 @@ repository: https://github.com/segmentio/analytics_flutter/tree/main/packages/pl
 issue_tracker: https://github.com/segmentio/analytics_flutter/issues
 
 environment:
-  sdk: '>=2.19.3 <4.0.0'
-  flutter: ">=1.17.0"
+  sdk: '>=3.2.0 <4.0.0'
+  flutter: ">=3.16.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  segment_analytics: ^1.0.0
-  json_annotation: ^4.8.0
-  appsflyer_sdk: ^6.9.3
+  segment_analytics: ^1.1.1
+  json_annotation: ^4.9.0
+  appsflyer_sdk: ^6.15.1
 
 dev_dependencies:
-  build_runner: ^2.3.3
-  json_serializable: ^6.6.0
+  build_runner: ^2.4.7
+  json_serializable: ^6.8.0
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.0
+  flutter_lints: ^4.0.0
 
-flutter:
 


### PR DESCRIPTION
chore(dependencies): Updated segment_analytics_plugin_appsflyer dependencies.

- Updates appsflyer_sdk to 6.15.1 now inherit Privacy Manifest from Native SDK via cocoapods.
- Updates minimum supported SDK version to Flutter 3.16/Dart 3.2
- Updates json_annotation to 4.9.0
- Updates segment_analytics to 1.1.1