### PR TITLE
Add utc method to timestamp

### DIFF
--- a/packages/core/lib/event.dart
+++ b/packages/core/lib/event.dart
@@ -577,7 +577,7 @@ mixin JSONExtendable {
 
 void applyRawEventData(RawEvent event) {
   event.messageId ??= const Uuid().v4();
-  event.timestamp ??= DateTime.now().toIso8601String();
+  event.timestamp ??= DateTime.now().toUtc().toIso8601String();
 }
 
 UserTraits mergeUserTraits(UserTraits a, UserTraits b) {


### PR DESCRIPTION
Follow up on this PR. https://github.com/segmentio/analytics_flutter/pull/105/files

We also need to set the timestamp to UTC as per our docs: https://segment.com/docs/connections/spec/common/#timestamps

> Every API call has four timestamps, originalTimestamp, timestamp, sentAt, and receivedAt. They’re used for very different purposes.
> 
> All timestamps are [ISO-8601](http://en.wikipedia.org/wiki/ISO_8601) date strings, and are in the UTC timezone. To see the user’s timezone information, check the timezone field that’s automatically collected by [client-side libraries](https://segment.com/docs/connections/spec/common/#context-fields-automatically-collected).