### PR TITLE
Fix: Prevent failed events from being dequeued

### DIFF
--- a/packages/core/lib/plugins/segment_destination.dart
+++ b/packages/core/lib/plugins/segment_destination.dart
@@ -35,10 +35,11 @@ class SegmentDestination extends DestinationPlugin with Flushable {
         final succeeded = await analytics?.httpClient.startBatchUpload(
             analytics!.state.configuration.state.writeKey, batch,
             host: _apiHost);
-        if (succeeded == null || !succeeded) {
+        if (succeeded == true) {
+          sentEvents.addAll(batch);
+        } else {
           numFailedEvents += batch.length;
         }
-        sentEvents.addAll(batch);
       } catch (e) {
         numFailedEvents += batch.length;
       } finally {


### PR DESCRIPTION
In `SegmentDestination`, ensure that only events that were sent successfully are added to the `sentEvents` list. This allows failed events to remain in the queue and be retried in the next attempt.