### PR TITLE
Refactor: Move dequeue outside loop for efficiency

### DIFF
--- a/packages/core/lib/plugins/segment_destination.dart
+++ b/packages/core/lib/plugins/segment_destination.dart
@@ -41,12 +41,11 @@ class SegmentDestination extends DestinationPlugin with Flushable {
         sentEvents.addAll(batch);
       } catch (e) {
         numFailedEvents += batch.length;
-      } finally {
-        _queuePlugin.dequeue(sentEvents);
       }
     });
 
     if (sentEvents.isNotEmpty) {
+      _queuePlugin.dequeue(sentEvents);
       log("Sent ${sentEvents.length} events", kind: LogFilterKind.debug);
     }
 


### PR DESCRIPTION
Moved `_queuePlugin.dequeue(sentEvents)` outside the Future.forEach loop to run once after all batches, instead of dequeuing already dequeued events per iteration.