### PR TITLE
Fix conditional import after migration to package:web 

### DIFF
--- a/packages/core/lib/utils/store/impl.dart
+++ b/packages/core/lib/utils/store/impl.dart
@@ -1,3 +1,3 @@
 export 'unsupported.dart'
-    if (dart.library.html) 'web.dart'
+    if (dart.library.js_interop) 'web.dart'
     if (dart.library.io) 'io.dart';


### PR DESCRIPTION
Since the project was migrated to `package:web` in https://github.com/segmentio/analytics_flutter/pull/79, we need to update the conditional imports to ensure compatibility with WASM.