### PR TITLE
fix(web): decode JSON-stringified ajs_anonymous_id from localStorage (#196)

### DIFF
--- a/packages/core/lib/utils/store/web.dart
+++ b/packages/core/lib/utils/store/web.dart
@@ -89,6 +89,16 @@ class StoreImpl implements Store {
         }
       }
     }
+
+    if (anonymousId != null) {
+      try {
+        final decoded = json.decode(anonymousId);
+        if (decoded is String) {
+          anonymousId = decoded;
+        }
+      } catch (_) {}
+    }
+
     return anonymousId ?? '';
   }
 }


### PR DESCRIPTION
## Fix for Issue #196: Decode JSON-stringified ajs_anonymous_id from localStorage

### Problem

`analytics.js` (the Segment JavaScript SDK) stores `ajs_anonymous_id` in localStorage using `JSON.stringify()`, which wraps the UUID in surrounding double-quote characters. The Flutter SDK's `getExistingAnonymousId()` reads this value via `localStorage.getItem()` but does not decode it, so the quotes become part of the anonymous ID string.

This causes identity mismatches between the JS and Flutter SDKs for any Flutter web app running on a domain where `analytics.js` has previously set `ajs_anonymous_id`.

### Fix

Added `json.decode` of the raw localStorage/cookie value in `getExistingAnonymousId()` with a try/catch fallback, so:
- JSON-stringified values (e.g. `"d039d945-..."`) are decoded to clean UUIDs
- Plain string values pass through unchanged
- Non-string or malformed values are left as-is

### Related

- Fixed GitHub Issue: #196

### Files Changed

- `packages/core/lib/utils/store/web.dart`