### PR TITLE
chore: add devbox environment for pinned Flutter 3.29.2 setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Automatically sets up your devbox environment whenever you cd into this
+# directory via our direnv integration.
+# Uses omit-nix-env as a temporary workaround: https://github.com/jetify-com/devbox/issues/1509
+
+eval "$(devbox shellenv --init-hook --install --no-refresh-alias --omit-nix-env=true)"
+
+# check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
+# for more details

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.14.2/.schema/devbox.schema.json",
+  "packages": {
+    "flutter": "3.29.2-sdk-links"
+  },
+  "shell": {
+    "init_hook": [
+      "export PROJECT_ROOT=\"$(git rev-parse --show-toplevel 2>/dev/null || echo $DEVBOX_PROJECT_ROOT)\""
+    ],
+    "scripts": {
+      "get": ["cd \"$PROJECT_ROOT/packages/core\" && flutter pub get"],
+      "analyze": ["cd \"$PROJECT_ROOT/packages/core\" && flutter analyze"],
+      "test": ["cd \"$PROJECT_ROOT/packages/core\" && flutter test --coverage"],
+      "check": [
+        "devbox run get",
+        "devbox run analyze",
+        "devbox run test"
+      ],
+      "codegen": ["cd \"$PROJECT_ROOT/packages/core\" && bash build_json_models.sh"],
+      "pigeon": ["cd \"$PROJECT_ROOT/packages/core\" && bash build_pigeon_plugins.sh"]
+    }
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,57 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "flutter@3.29.2-sdk-links": {
+      "last_modified": "2025-04-17T05:47:26Z",
+      "resolved": "github:NixOS/nixpkgs/ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c#flutter",
+      "source": "devbox-search",
+      "version": "3.29.2-sdk-links",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/794lymy0hm702i1sh3gh2n1yxlzf9pcm-flutter-wrapped-3.29.2-sdk-links",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/794lymy0hm702i1sh3gh2n1yxlzf9pcm-flutter-wrapped-3.29.2-sdk-links"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/4gm4n0pj4dj6hcrkf13dn94vf25wm505-flutter-wrapped-3.29.2-sdk-links",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/4gm4n0pj4dj6hcrkf13dn94vf25wm505-flutter-wrapped-3.29.2-sdk-links"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/lwwg75lpllgacss5xjs4wfcnrri6biza-flutter-wrapped-3.29.2-sdk-links",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/lwwg75lpllgacss5xjs4wfcnrri6biza-flutter-wrapped-3.29.2-sdk-links"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/g32kahvyc0lxy8zl8kfrcffv7nvb6fkd-flutter-wrapped-3.29.2-sdk-links",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/g32kahvyc0lxy8zl8kfrcffv7nvb6fkd-flutter-wrapped-3.29.2-sdk-links"
+        }
+      }
+    },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2026-05-06T02:58:03Z",
+      "resolved": "github:NixOS/nixpkgs/ed67bc86e84e51d4a88e73c7fd36006dc876476f?lastModified=1778036283&narHash=sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE%3D"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `devbox.json` pinning Flutter 3.29.2 (matching CI) as the sole managed dependency
- Adds `.envrc` for automatic direnv activation (same pattern as analytics-react-native)
- Adds `devbox.lock` for reproducible installs
- Provides `devbox run` scripts for all common workflows: `get`, `analyze`, `test`, `check`, `codegen`, `pigeon`

## Test plan
- [ ] `devbox shell` enters environment with Flutter 3.29.2 on PATH
- [ ] `devbox run get` resolves all deps
- [ ] `devbox run analyze` — no issues
- [ ] `devbox run test` — all 124 tests pass