### PR TITLE
chore: prepare release core 1.1.12 and plugin_idfa 1.0.2

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.12
+
+- Added Swift Package Manager support for iOS and macOS
+
 ## 1.1.11
 
 - Introduces file size checks on analytics-flutter-queue_flushing_plugin.json file so that the SDK avoids queuing events that would push the on-disk queue file above 512 KB.

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: segment_analytics
 description: The hassle-free way to add Segment analytics to your Flutter app.
-version: 1.1.11
+version: 1.1.12
 homepage: https://github.com/segmentio/analytics_flutter#readme
 repository: https://github.com/segmentio/analytics_flutter/tree/main/packages/core#readme
 issue_tracker: https://github.com/segmentio/analytics_flutter/issues

--- a/packages/plugins/plugin_idfa/CHANGELOG.md
+++ b/packages/plugins/plugin_idfa/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.2
+
+- Added Swift Package Manager support for iOS
+- Fixed IDFA plugin not populating advertisingId on initial events
+
 ## 1.0.0
 
 - Initial version, based off the React Native implementation (@segment/analytics-react-native-plugin-idfa) v0.5.0

--- a/packages/plugins/plugin_idfa/pubspec.yaml
+++ b/packages/plugins/plugin_idfa/pubspec.yaml
@@ -1,6 +1,6 @@
 name: segment_analytics_plugin_idfa
 description: The hassle-free way to add Segment analytics to your Flutter app.
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/segmentio/analytics_flutter#readme
 repository: https://github.com/segmentio/analytics_flutter/tree/main/packages/plugins/plugin_idfa#readme
 issue_tracker: https://github.com/segmentio/analytics_flutter/issues


### PR DESCRIPTION
## Summary
- Bumps `segment_analytics` to 1.1.12 and `segment_analytics_plugin_idfa` to 1.0.2
- Adds changelog entries for Swift Package Manager support and IDFA fix

## Test plan
- [x] `flutter analyze` passes
- [x] `flutter test` passes (126 tests)
- [x] `flutter pub publish --dry-run` from each package after merge