### PR TITLE
fix(android): use a unique namespace to avoid collision with analytics-kotlin under AGP 9

### DIFF
--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace 'com.segment.analytics'
+    namespace 'com.segment.analytics.flutter'
     compileSdkVersion 35 //Patch for for Github issue #147
 
     compileOptions {

--- a/packages/core/android/src/main/AndroidManifest.xml
+++ b/packages/core/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.segment.analytics">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
Fixes #214.

The core plugin declared `namespace 'com.segment.analytics'`, which collides with `com.segment.analytics.kotlin:android` when both end up in an app's dependency graph (common via SDKs that embed analytics-kotlin, e.g. Customer.io). AGP 9 escalates duplicate namespaces to a hard manifest-merger error — full repro and error output in #214.

Changes:
- `packages/core/android/build.gradle`: `namespace 'com.segment.analytics'` → `'com.segment.analytics.flutter'`
- `packages/core/android/src/main/AndroidManifest.xml`: drop the deprecated `package=` attribute (superseded by the gradle `namespace`)

The namespace only determines the generated `R`/`BuildConfig` package; Dart API and Kotlin source packages are unchanged. Note for consumers pinning ProGuard/R8 rules to the old `BuildConfig` package: this is technically observable, so it may warrant a minor version bump.

We've shipped this patch in production since June via a fork.
