### PR TITLE
Bump flutter_fgbg to ^0.8.0 for Swift Package Manager support

### DIFF
--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace 'com.segment.analytics'
+    namespace 'com.segment.analytics.flutter'
     compileSdkVersion 35 //Patch for for Github issue #147
 
     compileOptions {

--- a/packages/core/android/src/main/AndroidManifest.xml
+++ b/packages/core/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.segment.analytics">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   http: ">=0.13.6 <2.0.0"
   logger: ^2.4.0
   path_provider: ^2.1.4
-  flutter_fgbg: ^0.7.1
+  flutter_fgbg: ^0.8.0
   shared_preferences: ^2.2.2
   web: ^1.1.1
 


### PR DESCRIPTION
flutter_fgbg 0.8.0 (released 2026-03-30) adds a Swift Package Manager manifest (`ios/flutter_fgbg/Package.swift`) with no API changes — its changelog entry is just "Swift package manager migration".

Since #202/#203 added SPM support to the core plugin, `flutter_fgbg` 0.7.1 is the only transitive dependency of `segment_analytics` that still lacks a Swift package, so host apps building with Flutter's SPM integration still fall back to CocoaPods for it. Bumping the constraint to `^0.8.0` removes that last CocoaPods requirement.